### PR TITLE
Add filtering to repo selection, and the option to chose an org instead of personal repos

### DIFF
--- a/run.py
+++ b/run.py
@@ -50,6 +50,10 @@ for repo in repositories:
         print("Repo belongs to a organization. Skipping...")
         continue
 
+    if not repo.permissions.admin:
+        print("You don't have admin permissions on the repo. Skipping...")
+        continue
+
     topic_list = repo.get_topics()
 
     if "hacktoberfest" in topic_list and args.action == "remove":

--- a/run.py
+++ b/run.py
@@ -42,16 +42,12 @@ except BadCredentialsException:
 for repo in repositories:
     print(f"> Checking {repo.full_name}:")
 
-    if repo.private or repo.fork or repo.archived:
-        print("Repo is private, a fork or archived. Skipping...")
+    if repo.fork or repo.archived:
+        print("Repo is a fork or archived. Skipping...")
         continue
 
     if not args.organization and repo.organization is not None:
         print("Repo belongs to a organization. Skipping...")
-        continue
-
-    if not args.organization and repo.owner.id != user_id:
-        print("Repo does not belong to you. Skipping...")
         continue
 
     topic_list = repo.get_topics()

--- a/run.py
+++ b/run.py
@@ -15,7 +15,7 @@ def write_topics(repo, topiclist, dry_run):
 parser = argparse.ArgumentParser(
     description="Quickly add/remove the 'hacktoberfest' topic to all of your public Github projects"
 )
-parser.add_argument("action", type=str, help="'add' or 'remve' the topic", choices=["add", "remove"])
+parser.add_argument("action", type=str, help="'add' or 'remove' the topic", choices=["add", "remove"])
 parser.add_argument("--dry-run", action="store_true", help="Don't actually modify the topics")
 args = parser.parse_args()
 

--- a/run.py
+++ b/run.py
@@ -16,6 +16,7 @@ parser = argparse.ArgumentParser(
     description="Quickly add/remove the 'hacktoberfest' topic to all of your public Github projects"
 )
 parser.add_argument("action", type=str, help="'add' or 'remove' the topic", choices=["add", "remove"])
+parser.add_argument("--organization", "-o", help="Modify topics for an organization, not your personal projects")
 parser.add_argument("--dry-run", action="store_true", help="Don't actually modify the topics")
 args = parser.parse_args()
 
@@ -28,24 +29,28 @@ except KeyError:
 g = Github(token)
 
 try:
-    user_repositories = list(g.get_user().get_repos())
+    print("Getting list of repositories")
+    if args.organization:
+        repositories = [r for r in g.get_user().get_repos(affiliation = "organization_member", visibility = "public") if r.organization.login == args.organization]
+    else:
+        repositories = list(g.get_user().get_repos(affiliation = "owner", visibility = "public"))
     user_id = g.get_user().id
 except BadCredentialsException:
     print("Token is invalid or has the wrong permissions")
     exit(1)
 
-for repo in user_repositories:
+for repo in repositories:
     print(f"> Checking {repo.full_name}:")
 
     if repo.private or repo.fork or repo.archived:
         print("Repo is private, a fork or archived. Skipping...")
         continue
 
-    if repo.organization is not None:
+    if not args.organization and repo.organization is not None:
         print("Repo belongs to a organization. Skipping...")
         continue
 
-    if repo.owner.id != user_id:
+    if not args.organization and repo.owner.id != user_id:
         print("Repo does not belong to you. Skipping...")
         continue
 


### PR DESCRIPTION
Previously, all repos the user has access to were selected, and then 
they were dismissed later on, which led to much output, and longer 
runtimes. Now, repos are selcted based on visibility and ownership when 
getting the repo list.

Also, you can now specify an organization to modify instead of your 
personal repositories.